### PR TITLE
Fix manager filter parameter order

### DIFF
--- a/views/define/views/director/dashboard.php
+++ b/views/define/views/director/dashboard.php
@@ -72,7 +72,10 @@
     $subsidiaries = $filterController->getSubsidiaries();
     $agencies = $filterController->getAgencies($filters['subsidiary'] ?? 'all');
     $brands = $filterController->getBrands($filters);
-    $managers = $filterController->getManagers($filters);
+    $managers = $filterController->getManagers(
+        $filters['subsidiary'] ?? 'all',
+        $filters['agency'] ?? 'all'
+    );
     $technicians = $filterController->getTechnicians($filters);
 
     /* ----------  disponibilité niveaux pour le sélecteur  ---------- */


### PR DESCRIPTION
## Summary
- pass subsidiary and agency to `getManagers()` instead of entire filters array

## Testing
- `php -l views/define/views/director/dashboard.php`
- `php tests/ExportTaskRepositoryTest.php` *(fails: Class 'Infrastructure\Mongo\ExportTaskRepository' not found)*

------
https://chatgpt.com/codex/tasks/task_e_686388b6a6d4832bb77916703fcab601