### PR TITLE
Update agency filter and brand logo paths

### DIFF
--- a/views/define/components/agencyData.php
+++ b/views/define/components/agencyData.php
@@ -1,0 +1,15 @@
+<?php
+// Mapping of subsidiaries to their agencies
+return [
+    'CFAO MOTORS BURKINA' => ['Ouaga'],
+    'CAMEROON MOTORS INDUSTRIES' => ['Bafoussam', 'Bertoua', 'Douala', 'Garoua', 'Ngaoundere', 'Yaoundé'],
+    'CFAO MOTORS CONGO' => ['Brazzaville', 'Pointe-Noire'],
+    "CFAO MOTORS COTE D'IVOIRE" => ['Vridi - Equip'],
+    'CFAO MOTORS GABON' => ['Libreville'],
+    'CFAO MOTORS MADAGASCAR' => ['Ankorondrano', 'Anosizato', 'Diego', 'Moramanga', 'Tamatave'],
+    'CFAO MOTORS MALI' => ['Bamako'],
+    'CFAO MOTORS CENTRAFRIQUE' => ['Bangui'],
+    'CFAO MOTORS RDC' => ['Kinshasa', 'Kolwezi', 'Lubumbashi'],
+    'CFAO MOTORS SENEGAL' => ['Dakar'],
+];
+?>

--- a/views/define/components/filterAgency.php
+++ b/views/define/components/filterAgency.php
@@ -3,6 +3,17 @@
 
 function renderFilterAgency($selectedAgency = 'all', $agencies = [], $isEnabled = false) {
     $disabled = $isEnabled ? '' : 'disabled';
+
+    // Si aucun tableau d'agences n'est fourni, on tente de charger celui
+    // défini pour la filiale sélectionnée dans agencyData.php
+    if ($isEnabled && empty($agencies)) {
+        $subsidiary = $_GET['subsidiary'] ?? $_SESSION['subsidiary'] ?? '';
+        $agencyMap = include __DIR__ . '/agencyData.php';
+        if ($subsidiary && isset($agencyMap[$subsidiary])) {
+            $agencies = $agencyMap[$subsidiary];
+        }
+    }
+
     echo '<label for="filterAgency" class="form-label">Filtrer par Agence</label>';
     echo '<select id="filterAgency" class="form-select" name="agency" aria-label="Filtrer par Agence" ' . $disabled . '>';
     echo '<option value="all">Toutes les Agences</option>';

--- a/views/define/views/director/dashboard.php
+++ b/views/define/views/director/dashboard.php
@@ -2365,7 +2365,8 @@ document.addEventListener('DOMContentLoaded', function() {
             
             // Get logo filename from mapping or use default
             const logoFilename = chartData.brandLogos[brand] || 'default-logo.png';
-            img.src = `/MEDACAP/public/images/${logoFilename}`;
+            // Les logos sont stockés dans le dossier 'brands'
+            img.src = `../../brands/${logoFilename}`;
             img.alt = brand;
             img.title = brand;
             img.style.maxWidth = '100%';


### PR DESCRIPTION
## Summary
- centralize agency lists for each subsidiary
- load agency data in `filterAgency` when none provided
- fetch brand logos from the `brands` directory in director dashboard

## Testing
- `php -l views/define/components/filterAgency.php`
- `php -l views/define/components/agencyData.php`
- `php -l views/define/views/director/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_6863b5d7883c832b9df1c1e163f5f57d